### PR TITLE
Remove unnecessary and bad `version: 0.2` from win-error.opam

### DIFF
--- a/win-error.opam
+++ b/win-error.opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 name: "win-error"
-version: "0.2"
 maintainer: "dave@recoil.org"
 authors: "David Scott"
 license: "ISC"


### PR DESCRIPTION
Fixes #6

Signed-off-by: David Scott <dave@recoil.org>