### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/win-error.opam
+++ b/win-error.opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "3.12.1"}
   "base-bytes"
   "base-unix"
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.